### PR TITLE
Remove RHEL7 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ These dates correspond to Mountain Standard Time.
 * Switch to main Tomcat mirror in _get-latest.sh_.
 * Removed the broken RPM signing code and inserted the rest of _build.sh_ into _get-latest.sh_.
 * Changed remaining _uostomcat_ references in RPM Spec File to _tomcat_.
+* Remove references to RHEL7 from the README file.
 
 ### 03-29-2021
 * Removed commented-out code from _get-latest.sh_ related to the unimplemented Tomcat Native Spec File.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,8 @@
 # tomcat-rpm-spec
-RPM spec for Tomcat (currently 8.5, but can be use for future versions) on RHEL7
+RPM spec for Tomcat (currently 8.5, but can be use for future versions)
+
+Contains a script to update the SPEC file to match the latest update of a given Major/Minor release
+
+It can also build the SPEC file
 
 Please read the CHANGELOG for more info on what has changed compared to the original
-
-To use this, install rpmbuild and then build a rpm tree:
-
-mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-
-place the contents of 'SPECS' and 'SOURCES' from this repo into the directories created above.
-
-then download the latest version of Apache Tomcat and place the tar.gz in "SOURCES"
-
-Adjust the tomcat.spec file to match the version number you downloaded.
-
-Then cd into SPECS and run:
-
-rpmbuild -bb tomcat.spec


### PR DESCRIPTION
It appears to work on the latest version of Fedora and it should work on other similar distros.